### PR TITLE
fix: exlude allocator from AuctionsThroughputView

### DIFF
--- a/maker/views/liquidations.py
+++ b/maker/views/liquidations.py
@@ -286,7 +286,7 @@ class AuctionsThroughputView(APIView):
     def get(self, request):
         data = []
         percent_liquidated = float(request.GET.get("percent_liquidated", 20)) / 100
-        ilks = Ilk.objects.active().exclude(collateral__in=["PSM", "DIRECT"])
+        ilks = Ilk.objects.active().exclude(collateral__in=["PSM", "DIRECT", "ALLOCATOR"])
         for ilk in ilks.exclude(collateral__contains="RWA"):
             auction_data = get_auction_throughput_data_for_ilk(ilk)
             if not auction_data["current_hole"]:

--- a/maker/views/liquidations.py
+++ b/maker/views/liquidations.py
@@ -286,7 +286,9 @@ class AuctionsThroughputView(APIView):
     def get(self, request):
         data = []
         percent_liquidated = float(request.GET.get("percent_liquidated", 20)) / 100
-        ilks = Ilk.objects.active().exclude(collateral__in=["PSM", "DIRECT", "ALLOCATOR"])
+        ilks = Ilk.objects.active().exclude(
+            collateral__in=["PSM", "DIRECT", "ALLOCATOR"]
+        )
         for ilk in ilks.exclude(collateral__contains="RWA"):
             auction_data = get_auction_throughput_data_for_ilk(ilk)
             if not auction_data["current_hole"]:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Auction throughput metrics now employ improved filtering criteria that remove an additional type of item from calculations. As a result, users will experience a more accurate and consistent display of auction data, leading to enhanced clarity in performance metrics and potentially more reliable insights. This update improves overall auction transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->